### PR TITLE
Fix builds after branch was deleted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,14 @@ services:
     ports:
       - 9292:80
 
-  traced-httpd-centos6:
-    build:
-      context: .
-      dockerfile: docker/centos6/Dockerfile
-    ports:
-      - 9393:80
+  # Extra hackery required since this is now officially EOL
+  # and can't even yum install
+  # traced-httpd-centos6:
+  #   build:
+  #     context: .
+  #     dockerfile: docker/centos6/Dockerfile
+  #   ports:
+  #     - 9393:80
 
   traced-httpd-centos8:
     build:

--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -10,9 +10,9 @@ ENV MANPATH=/opt/rh/devtoolset-9/root/usr/share/man: \
     PATH=/opt/rh/devtoolset-9/root/usr/bin:/opt/rh/httpd24/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     PKG_CONFIG_PATH=/opt/rh/devtoolset-9/root/usr/lib64/pkgconfig \
     INFOPATH=/opt/rh/devtoolset-9/root/usr/share/info
-RUN mkdir -p /var/tmp/localbuild/dd-trace-httpd/ddtrace
+RUN mkdir -p /var/tmp/localbuild/dd-opentracing-cpp /var/tmp/localbuild/dd-trace-httpd/ddtrace
 WORKDIR /var/tmp/localbuild
-RUN cd /var/tmp/localbuild && git clone -b cgilmour/pic https://github.com/DataDog/dd-opentracing-cpp && cd dd-opentracing-cpp && ./scripts/install_dependencies.sh && mkdir .build && cd .build && cmake -DBUILD_SHARED=Off -DBUILD_STATIC=On .. && make && make install
+RUN cd /var/tmp/localbuild && wget https://github.com/DataDog/dd-opentracing-cpp/archive/b7c44dbd942bb064dac75b66d76b5d97f79a3f3c.tar.gz && tar zxf b7c44dbd942bb064dac75b66d76b5d97f79a3f3c.tar.gz -C dd-opentracing-cpp --strip-components=1 && cd dd-opentracing-cpp && ./scripts/install_dependencies.sh && mkdir .build && cd .build && cmake -DBUILD_SHARED=Off -DBUILD_STATIC=On .. && make && make install
 ADD ddtrace/ddtrace.h ddtrace/ddtrace.cpp ddtrace/mod_ddtrace.c ddtrace/Makefile ddtrace/modules.mk ddtrace/.deps /var/tmp/localbuild/dd-trace-httpd/ddtrace/
 WORKDIR /var/tmp/localbuild/dd-trace-httpd/ddtrace
 RUN make && g++ -shared -fPIC -DPIC .libs/mod_ddtrace.o .libs/ddtrace.o -L../../dd-opentracing-cpp/.build -L../../dd-opentracing-cpp/deps/lib -Wl,-Bstatic -ldd_opentracing -lopentracing -lcurl -lz -Wl,-Bdynamic -lpthread -lrt -O2 -Wl,--as-needed -Wl,-Bsymbolic-functions -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-soname -Wl,mod_ddtrace.so -o .libs/mod_ddtrace.so

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:8 AS build
-RUN yum -y install git zlib-devel wget make cmake gcc-c++ httpd-devel redhat-rpm-config
-RUN mkdir -p /var/tmp/localbuild/dd-trace-httpd/ddtrace
+RUN yum -y install git zlib-devel wget make cmake gcc-c++ httpd-devel redhat-rpm-config libarchive
+RUN mkdir -p /var/tmp/localbuild/dd-opentracing-cpp /var/tmp/localbuild/dd-trace-httpd/ddtrace
 WORKDIR /var/tmp/localbuild
-RUN cd /var/tmp/localbuild && git clone -b cgilmour/pic https://github.com/DataDog/dd-opentracing-cpp && cd dd-opentracing-cpp && ./scripts/install_dependencies.sh && mkdir .build && cd .build && cmake -DBUILD_SHARED=Off -DBUILD_STATIC=On .. && make && make install
+RUN cd /var/tmp/localbuild && wget https://github.com/DataDog/dd-opentracing-cpp/archive/b7c44dbd942bb064dac75b66d76b5d97f79a3f3c.tar.gz && tar zxf b7c44dbd942bb064dac75b66d76b5d97f79a3f3c.tar.gz -C dd-opentracing-cpp --strip-components=1 && cd dd-opentracing-cpp && ./scripts/install_dependencies.sh && mkdir .build && cd .build && cmake -DBUILD_SHARED=Off -DBUILD_STATIC=On .. && make && make install
 ADD ddtrace/ddtrace.h ddtrace/ddtrace.cpp ddtrace/mod_ddtrace.c ddtrace/Makefile ddtrace/modules.mk ddtrace/.deps /var/tmp/localbuild/dd-trace-httpd/ddtrace/
 WORKDIR /var/tmp/localbuild/dd-trace-httpd/ddtrace
 RUN make && g++ -shared -fPIC -DPIC .libs/mod_ddtrace.o .libs/ddtrace.o -L../../dd-opentracing-cpp/.build -L../../dd-opentracing-cpp/deps/lib -Wl,-Bstatic -ldd_opentracing -lopentracing -lcurl -lz -Wl,-Bdynamic -lpthread -lrt -O2 -Wl,--as-needed -Wl,-Bsymbolic-functions -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-soname -Wl,mod_ddtrace.so -o .libs/mod_ddtrace.so
@@ -12,6 +12,5 @@ RUN yum -y install httpd
 COPY --from=build /var/tmp/localbuild/dd-trace-httpd/ddtrace/.libs/mod_ddtrace.so /usr/lib64/httpd/modules/mod_ddtrace.so
 COPY docker/centos8/00-ddtrace.conf /etc/httpd/conf.modules.d/
 COPY docker/centos8/run-httpd.sh /
-RUN cp /usr/share/httpd/noindex/index.html.en-US /var/www/html/index.html
-RUN cp -r /usr/share/httpd/noindex/common /var/www/html/
+RUN cp /usr/share/testpage/index.html /var/www/html/index.html
 CMD ["/run-httpd.sh"]

--- a/docker/ubuntu1804/Dockerfile
+++ b/docker/ubuntu1804/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04 AS build
 RUN apt-get update && apt-get -y install build-essential apache2-dev cmake git wget
-RUN mkdir -p /var/tmp/localbuild/dd-trace-httpd/ddtrace
+RUN mkdir -p /var/tmp/localbuild/dd-opentracing-cpp /var/tmp/localbuild/dd-trace-httpd/ddtrace
 WORKDIR /var/tmp/localbuild
-RUN cd /var/tmp/localbuild && git clone -b cgilmour/pic https://github.com/DataDog/dd-opentracing-cpp && cd dd-opentracing-cpp && ./scripts/install_dependencies.sh && mkdir .build && cd .build && cmake -DBUILD_SHARED=Off -DBUILD_STATIC=On .. && make && make install
+RUN cd /var/tmp/localbuild && wget https://github.com/DataDog/dd-opentracing-cpp/archive/b7c44dbd942bb064dac75b66d76b5d97f79a3f3c.tar.gz && tar zxf b7c44dbd942bb064dac75b66d76b5d97f79a3f3c.tar.gz -C dd-opentracing-cpp --strip-components=1 && cd dd-opentracing-cpp && ./scripts/install_dependencies.sh && mkdir .build && cd .build && cmake -DBUILD_SHARED=Off -DBUILD_STATIC=On .. && make && make install
 ADD ddtrace/ddtrace.h ddtrace/ddtrace.cpp ddtrace/mod_ddtrace.c ddtrace/Makefile ddtrace/modules.mk ddtrace/.deps /var/tmp/localbuild/dd-trace-httpd/ddtrace/
 WORKDIR /var/tmp/localbuild/dd-trace-httpd/ddtrace
 RUN make && g++ -shared -fPIC -DPIC .libs/mod_ddtrace.o .libs/ddtrace.o -L../../dd-opentracing-cpp/.build -L../../dd-opentracing-cpp/deps/lib -Wl,-Bstatic -ldd_opentracing -lopentracing -lcurl -lz -Wl,-Bdynamic -lpthread -O2 -Wl,--as-needed -Wl,-Bsymbolic-functions -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-soname -Wl,mod_ddtrace.so -o .libs/mod_ddtrace.so


### PR DESCRIPTION
Fixes #1 for ubuntu 18.04 and centos 8 but doesn't build centos 6 because the base image seems to need some magic to work.
The base `centos:6` image fails basic `yum install` with the error
```
YumRepo Error: All mirror URLs are not using ftp, http[s] or file.
 Eg. Invalid release/repo/arch combination/
removing mirrorlist with no valid mirrors: /var/cache/yum/x86_64/6/base/mirrorlist.txt
Error: Cannot retrieve repository metadata (repomd.xml) for repository: base. Please verify its path and try again
```